### PR TITLE
[2024-07-22] 회원가입 전 인증코드 구현/ 관리자 페이지 인증코드 발급 구현

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,14 +4,30 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="69926207-5b43-4876-b095-05d7c27fba30" name="Changes" comment="[2024-07-18]안전 점검 프론트">
-      <change beforePath="$PROJECT_DIR$/.idea/inspectionProfiles/Project_Default.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/inspectionProfiles/Project_Default.xml" afterDir="false" />
+    <list default="true" id="69926207-5b43-4876-b095-05d7c27fba30" name="Changes" comment="[2024-07-21] 프로필 사진 crop">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/package-lock.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/layouts/FullLayout.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/layouts/FullLayout.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/layouts/sidebars/sidebardata/SidebarData.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/layouts/sidebars/sidebardata/SidebarData.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/routes/Router.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/routes/Router.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/store/apps/login/userSlice.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/store/apps/login/userSlice.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/views/airportStore/airportStoreDBUpdate.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/views/airportStore/airportStoreDBUpdate.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/views/auth/Error.scss" beforeDir="false" afterPath="$PROJECT_DIR$/src/views/auth/Error.scss" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/views/auth/RegisterFormik.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/views/auth/RegisterFormik.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/views/auth/imgUpload.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/views/auth/imgUpload.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
     <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="JavaScript File" />
+      </list>
+    </option>
   </component>
   <component name="Git.Settings">
     <option name="RECENT_BRANCH_BY_REPOSITORY">
@@ -30,20 +46,23 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "git-widget-placeholder": "feature/inspection",
-    "kotlin-language-version-configured": "true",
-    "last_opened_file_path": "C:/lecture/fianl",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;Node.js.imgUpload.js.executor&quot;: &quot;Run&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature/profileImg&quot;,
+    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/lecture/fianl&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.pluginManager&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;/Applications/IntelliJ IDEA.app/Contents/plugins/javascript-plugin/jsLanguageServicesImpl/external&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RunManager">
     <configuration default="true" type="JetRunConfigurationType">
       <module name="airport" />
@@ -62,8 +81,8 @@
   <component name="SharedIndexes">
     <attachedChunks>
       <set>
-        <option value="bundled-jdk-9f38398b9061-18abd8497189-intellij.indexing.shared.core-IU-241.14494.240" />
-        <option value="bundled-js-predefined-1d06a55b98c1-74d2a5396914-JavaScript-IU-241.14494.240" />
+        <option value="bundled-jdk-9f38398b9061-39b83d9b5494-intellij.indexing.shared.core-IU-241.15989.150" />
+        <option value="bundled-js-predefined-1d06a55b98c1-91d5c284f522-JavaScript-IU-241.15989.150" />
       </set>
     </attachedChunks>
   </component>
@@ -81,6 +100,10 @@
       <workItem from="1721269524012" duration="8000" />
       <workItem from="1721280519575" duration="137000" />
       <workItem from="1721348602437" duration="1025000" />
+      <workItem from="1721615003682" duration="3839000" />
+      <workItem from="1721620286186" duration="57000" />
+      <workItem from="1721620358586" duration="680000" />
+      <workItem from="1721621055933" duration="14163000" />
     </task>
     <task id="LOCAL-00001" summary="[2024-07-18]안전 점검 프론트">
       <option name="closed" value="true" />
@@ -90,14 +113,43 @@
       <option name="project" value="LOCAL" />
       <updated>1721280462446</updated>
     </task>
-    <option name="localTasksCounter" value="2" />
+    <task id="LOCAL-00002" summary="[2024-07-19] 프로필 수정하기 이미지 추가">
+      <option name="closed" value="true" />
+      <created>1721374821233</created>
+      <option name="number" value="00002" />
+      <option name="presentableId" value="LOCAL-00002" />
+      <option name="project" value="LOCAL" />
+      <updated>1721374821233</updated>
+    </task>
+    <task id="LOCAL-00003" summary="[2024-07-21] 프로필 사진 crop">
+      <option name="closed" value="true" />
+      <created>1721562154661</created>
+      <option name="number" value="00003" />
+      <option name="presentableId" value="LOCAL-00003" />
+      <option name="project" value="LOCAL" />
+      <updated>1721562154661</updated>
+    </task>
+    <option name="localTasksCounter" value="4" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
     <option name="version" value="3" />
   </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State />
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
   <component name="VcsManagerConfiguration">
     <MESSAGE value="[2024-07-18]안전 점검 프론트" />
-    <option name="LAST_COMMIT_MESSAGE" value="[2024-07-18]안전 점검 프론트" />
+    <MESSAGE value="[2024-07-19] 프로필 수정하기 이미지 추가" />
+    <MESSAGE value="[2024-07-21] 프로필 사진 crop" />
+    <option name="LAST_COMMIT_MESSAGE" value="[2024-07-21] 프로필 사진 crop" />
   </component>
 </project>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,13 @@
   "dependencies": {
     "@casl/ability": "^6.5.0",
     "@casl/react": "^3.1.0",
+    "@emotion/react": "^11.13.0",
+    "@emotion/styled": "^11.13.0",
+    "@material-ui/core": "^4.12.4",
+    "@material-ui/icons": "^4.11.3",
     "@material/react-material-icon": "^0.15.0",
+    "@mui/icons-material": "^5.16.4",
+    "@mui/material": "^5.16.4",
     "@reduxjs/toolkit": "^1.9.7",
     "@svgr/rollup": "^8.1.0",
     "apexcharts": "^3.43.0",
@@ -26,6 +32,7 @@
     "draft-js": "^0.11.7",
     "firebase": "^10.12.3",
     "formik": "^2.4.5",
+    "get-orientation": "^1.1.2",
     "js-cookie": "^3.0.5",
     "moment": "^2.29.4",
     "namor": "^1.1.3",
@@ -40,6 +47,7 @@
     "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.2.0",
     "react-draft-wysiwyg": "^1.15.0",
+    "react-easy-crop": "^5.0.7",
     "react-feather": "^2.0.10",
     "react-hook-form": "^7.47.0",
     "react-iframe": "1.8.5",
@@ -58,6 +66,7 @@
     "sass": "^1.69.0",
     "simplebar": "^6.2.5",
     "simplebar-react": "^3.2.4",
+    "styled-components": "^6.1.12",
     "yup": "^1.3.2"
   },
   "devDependencies": {

--- a/src/layouts/FullLayout.js
+++ b/src/layouts/FullLayout.js
@@ -27,7 +27,6 @@ const FullLayout = () => {
   console.log('redux', userInfo);
 
   useEffect(() => {
-    // Check if userInfo is empty
     if (userInfo.userCode === null) {
       axios.get('http://localhost:8080/user-info', {
         headers: {
@@ -42,6 +41,8 @@ const FullLayout = () => {
         console.error('Error fetching user info:', error);
         navigate('/auth/loginformik')
       });
+    } else if (userInfo.isActive !== "Y"){
+      navigate('/auth/permission-error')
     }
   }, [dispatch, userInfo]);
 

--- a/src/layouts/sidebars/sidebardata/SidebarData.js
+++ b/src/layouts/sidebars/sidebardata/SidebarData.js
@@ -11,6 +11,20 @@ const SidebarData = [
   
   },
   {
+    title: '관리자',
+    href: '/',
+    icon: <MaterialIcon icon="how_to_reg" />,
+    id: 2.8,
+    collapisble: false,
+    children: [
+      {
+        title: '인증코드 발급',
+        href: '/code-issuance',
+        icon: <MaterialIcon icon="radio_button_checked" />,
+      },
+    ],
+  },
+  {
     title: '사용 승인',
     href: '/apps/notes',
     icon: <MaterialIcon icon="description" />,

--- a/src/routes/Router.js
+++ b/src/routes/Router.js
@@ -4,6 +4,9 @@ import Loadable from '../layouts/loader/Loadable';
 import ProfileUploader from '../views/auth/imgUpload';
 
 
+
+
+
 /****Layouts*****/
 
 const FullLayout = Loadable(lazy(() => import('../layouts/FullLayout')));
@@ -21,6 +24,7 @@ const BaggageClaim = Loadable(lazy(() => import('../views/airplane/BaggageClaim'
 const BaggageClaimDetail = Loadable(lazy(() => import('../views/airplane/BaggageClaimsDetail')));
 
 const Profile = Loadable(lazy(() => import('../views/auth/Profile')));
+const AuthCode = Loadable(lazy(() => import('../views/auth/AuthCode.js')));
 
 const Inspection = Loadable(lazy(() => import('../views/inspection/inspection')));
 const InspectionDetail = Loadable(lazy(() => import('../views/inspection/inspectionDetail')));
@@ -43,6 +47,8 @@ const CASL = Loadable(lazy(() => import('../views/apps/accessControlCASL/AccessC
 const Error = Loadable(lazy(() => import('../views/auth/Error')));
 const RegisterFormik = Loadable(lazy(() => import('../views/auth/RegisterFormik')));
 const LoginFormik = Loadable(lazy(() => import('../views/auth/LoginFormik')));
+const PermissionError = Loadable(lazy(() => import('../views/auth/PermissionError.js')));
+const Certification = Loadable(lazy(() => import('../views/auth/Certification.js')));
 
 
 /*****Routes******/
@@ -79,6 +85,8 @@ const ThemeRoutes = [
 
       { path: '/profile', name: 'profile', exact: true, element: <Profile /> },
       { path: '/upload', name: 'test', exact: true, element: <ProfileUploader /> },
+      { path: '/code-issuance', name: 'test', exact: true, element: <AuthCode /> },
+
 
     
       { path: '/casl', name: 'casl', exact: true, element: <CASL /> },
@@ -93,6 +101,8 @@ const ThemeRoutes = [
       { path: '*', element: <Navigate to="/auth/404" /> },
       { path: 'registerformik', element: <RegisterFormik /> },
       { path: 'loginformik', element: <LoginFormik /> },
+      { path: 'permission-error', element: <PermissionError /> },
+      { path: 'certification', element: <Certification /> },
     ],
   },
 ];

--- a/src/store/apps/login/userSlice.js
+++ b/src/store/apps/login/userSlice.js
@@ -11,6 +11,8 @@ const initialState = {
   userRole: '',
   userAbout : '',
   userImg : '',
+  isActive : '',
+  authCode : '',
 };
 
 const userInfoSlice = createSlice({
@@ -29,6 +31,7 @@ const userInfoSlice = createSlice({
       state.userRole = action.payload.userRole;
       state.userAbout = action.payload.userAbout;
       state.userImg = action.payload.userImg;
+      state.isActive = action.payload.isActive;
     },
     modifyUser: (state,action) => {
         state.userCode = action.payload.userCode;
@@ -37,10 +40,13 @@ const userInfoSlice = createSlice({
         state.userPhone = action.payload.userPhone;
         state.userAddress = action.payload.userAddress;
         state.userAbout = action.payload.userAbout;
+    },
+    addAuthCode: (state, action) => {
+      state.authCode = action.payload.password;
     }
   }
 });
 
-export const { addUser, modifyUser } = userInfoSlice.actions;
+export const { addUser, modifyUser,addAuthCode } = userInfoSlice.actions;
 
 export default userInfoSlice.reducer;

--- a/src/views/airportStore/airportStoreDBUpdate.js
+++ b/src/views/airportStore/airportStoreDBUpdate.js
@@ -30,7 +30,7 @@ const AirportDBUpdate = () => {
     }
 
     const onClickDB = () => {
-        api.post('/api/v1/store/insertapi',apiData)
+        api.post('/api/v1/store/api',apiData)
         .then(res => {
             alert('등록성공')
             navigate('/airport/store')

--- a/src/views/auth/AuthCode.js
+++ b/src/views/auth/AuthCode.js
@@ -1,0 +1,61 @@
+import React, {useState} from 'react';
+import {
+    Card,
+    CardBody,
+    Col,
+    Row,
+    Button, Alert,
+} from 'reactstrap';
+import BreadCrumbs from '../../layouts/breadcrumbs/BreadCrumbs';
+import api from "src/store/apps/airplane/api.js";
+
+const AuthCode = () => {
+
+    const [authInfo, setAuthInfo] = useState()
+    const [disabled, setDisabled] = useState(false)
+    console.log(authInfo)
+
+    const onClickHandler = () => {
+        api.get("/api/v1/admin/code")
+            .then(res => res.data)
+            .then(data => {
+                setAuthInfo(data.data);
+                setDisabled(true)
+            })
+            .catch(err => {
+                alert('다시 시도해주세요')
+                console.error('error',err);
+            })
+    }
+
+    return (
+        <>
+            <BreadCrumbs />
+
+                <CardBody className="p-4">
+                    <Row>
+                        <Col lg="4">
+                            <Card>
+                                <CardBody className="profile-card pt-4 d-flex flex-column align-items-center">
+                                    <Button color="primary" onClick={onClickHandler} disabled={disabled}>인증코드 발급</Button>
+                                    {authInfo ?
+                                    <Alert color="info" className="mt-3">인증코드는 {authInfo.authCode} 입니다.</Alert>
+                                    : null}
+                                </CardBody>
+                            </Card>
+                        </Col>
+                        <Col lg="8">
+                            <Card>
+                                <CardBody className="pt-3">
+
+                                </CardBody>
+                            </Card>
+                        </Col>
+                    </Row>
+                </CardBody>
+
+        </>
+    );
+};
+
+export default AuthCode;

--- a/src/views/auth/Certification.js
+++ b/src/views/auth/Certification.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import {
+    Button,
+    Label,
+    FormGroup,
+    CardTitle,
+    Container,
+    Row,
+    Col,
+    Card,
+    CardBody,
+} from 'reactstrap';
+import { useNavigate } from 'react-router-dom';
+import { Formik, Field, Form, ErrorMessage } from 'formik';
+import * as Yup from 'yup';
+import AuthLogo from '../../layouts/logo/AuthLogo';
+import { ReactComponent as LeftBg } from '../../assets/images/bg/login-bgleft.svg';
+import { ReactComponent as RightBg } from '../../assets/images/bg/login-bg-right.svg';
+import img1 from '../../assets/images/users/user4.jpg';
+import axios from "axios";
+import {useDispatch} from "react-redux";
+import {addAuthCode} from "src/store/apps/login/userSlice.js";
+
+const Certification = () => {
+
+    const navigate = useNavigate();
+    const dispatch = useDispatch();
+
+    const initialValues = {
+        password: '',
+    };
+
+    const validationSchema = Yup.object().shape({
+        password: Yup.string()
+            .min(6, '인증코드 6자리를 입력해주세요')
+            .required('인증코드를 입력해주세요'),
+    });
+
+    const submitHandler = (fields) => {
+        axios.post("http://localhost:8080/api/v1/auth",fields)
+            .then(res => {
+                dispatch(addAuthCode(fields))
+                navigate('/auth/registerformik')
+            })
+            .catch(err => {
+                alert('인증코드가 일치하지 않습니다.')
+                console.log(err);
+            })
+    }
+
+    return (
+        <div className="loginBox">
+            <LeftBg className="position-absolute left bottom-0" />
+            <RightBg className="position-absolute end-0 top" />
+            <Container fluid className="h-100">
+                <Row className="justify-content-center align-items-center h-100">
+                    <Col lg="12" className="loginContainer">
+                        <AuthLogo />
+                        <Card>
+                            <CardBody className="p-4 m-1">
+                                <div className="text-center">
+                                    <img src={img1} alt="avatar" className="rounded-circle" width="95" />
+                                    <CardTitle tag="h4" className="mt-2">
+                                        Welcome !
+                                    </CardTitle>
+                                </div>
+                                <Formik
+                                    initialValues={initialValues}
+                                    validationSchema={validationSchema}
+                                    onSubmit={submitHandler}
+                                    render={({ errors, touched }) => (
+                                        <Form className="mt-3">
+                                            <FormGroup>
+                                                <Label htmlFor="Code">인증코드를 입력하세요</Label>
+                                                <Field
+                                                    name="password"
+                                                    type="text"
+                                                    className={`form-control${
+                                                        errors.password && touched.password ? ' is-invalid' : ''
+                                                    }`}
+                                                />
+                                                <ErrorMessage
+                                                    name="password"
+                                                    component="div"
+                                                    className="invalid-feedback"
+                                                />
+                                            </FormGroup>
+                                            <FormGroup>
+                                                <Button type="submit" color="info" block className="me-2">
+                                                    Login
+                                                </Button>
+                                            </FormGroup>
+                                        </Form>
+                                    )}
+                                />
+                            </CardBody>
+                        </Card>
+                    </Col>
+                </Row>
+            </Container>
+        </div>
+    );
+};
+
+export default Certification;

--- a/src/views/auth/Error.scss
+++ b/src/views/auth/Error.scss
@@ -5,6 +5,13 @@
   line-height: 210px;
 }
 
+.error-title2 {
+  font-size: 100px;
+  font-weight: 900;
+  text-shadow: 4px 4px 0 #fff, 6px 6px 0 #263238;
+  line-height: 210px;
+}
+
 @media ( max-width: 1024px) {
     .error-title {
         font-size: 80px;

--- a/src/views/auth/PermissionError.js
+++ b/src/views/auth/PermissionError.js
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom';
+import "./Error.scss";
+import errorBg from '../../assets/images/background/error-bg.jpg';
+
+const PermissionError = () => {
+    return (
+        <>
+            <div
+                className="loginBox"
+                style={{ background: `url(${errorBg}) no-repeat bottom center #fff` }}
+            >
+                <div className="d-flex align-items-center justify-content-center h-100">
+                    <div className="text-center">
+                        <h1 className='error-title2'>No permission</h1>
+                        <div className="my-3">
+                            <h4>권한 없음</h4>
+                            <span className="text-muted d-block fs-5">
+                 관리자 승인이 있어야 접근 가능합니다.{' '}
+              </span>
+                        </div>
+
+                        <Link to="/" className="btn btn-danger">
+                            Back to home
+                        </Link>
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default PermissionError;

--- a/src/views/auth/RegisterFormik.js
+++ b/src/views/auth/RegisterFormik.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import { Button, Label, FormGroup, Container, Row, Col, Card, CardBody } from 'reactstrap';
 import { Formik, Field, Form, ErrorMessage } from 'formik';
 import * as Yup from 'yup';
@@ -7,10 +7,21 @@ import AuthLogo from "../../layouts/logo/AuthLogo";
 import { ReactComponent as LeftBg } from '../../assets/images/bg/login-bgleft.svg';
 import { ReactComponent as RightBg } from '../../assets/images/bg/login-bg-right.svg';
 import axios from 'axios';
+import {useSelector} from "react-redux";
 
 const RegisterFormik = () => {
 
   let navigate = useNavigate();
+
+  const userInfo = useSelector(state => state.userInfo);
+  console.log(userInfo.authCode);
+
+  useEffect(() => {
+    console.log(userInfo);
+    if(!userInfo.authCode) {
+      navigate('/auth/certification')
+    }
+  }, []);
 
   const initialValues = {
     userId: '',
@@ -20,8 +31,10 @@ const RegisterFormik = () => {
     confirmPassword: '',
     userPhone: '',
     acceptTerms: false,
+    authCode : parseInt(userInfo.authCode),
   };
 
+  console.log(initialValues);
   const validationSchema = Yup.object().shape({
     userId: Yup.string().required('아이디를 입력해주세요'),
     userName: Yup.string().required('이름을 입력해주세요'),

--- a/src/views/auth/imgUpload.js
+++ b/src/views/auth/imgUpload.js
@@ -47,7 +47,7 @@ const ProfileUploader = () => {
         setLoading(false);
       }
     } else {
-      alert("이미지와 사용자 코드를 입력하세요.");
+      alert("이미지를 입력하세요.");
     }
   };
 


### PR DESCRIPTION
- 제목 : 회원가입 전 인증코드 구현/ 관리자 페이지 인증코드 발급 구현
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- 회원가입 폼으로 강제 이동 시 redux 에 있는 authCode 가 비어있을 시 접근 불가 하게 추가
- 

  <br/>

## 이미지 첨부

![스크린샷 2024-07-22 오후 7 01 58](https://github.com/user-attachments/assets/e515f2b3-6a5d-43d8-8130-d1229beebbf8)


<br/>

## 🔧 앞으로의 과제

- 첫 화면 인증코드 입력화면으로 전환
- 이메일 or 휴대폰 인증 추가

  <br/>


<br/>
